### PR TITLE
Fix: Mollie module expects a token per order

### DIFF
--- a/Service/Order/MultishippingTransaction.php
+++ b/Service/Order/MultishippingTransaction.php
@@ -33,24 +33,25 @@ class MultishippingTransaction
     }
 
     /**
-     * @param OrderInterface[] $orders
-     * @param string $paymentToken
-     * @throws \Exception
+     * @param OrderInterface[] $orderList
+     * @param array $paymentTokens
+     *
      * @return string
+     *@throws \Exception
      */
-    public function getRedirectUrl(array $orders, string $paymentToken): string
+    public function getRedirectUrl(array $orderList, array $paymentTokens): string
     {
-        if (!$orders) {
+        if (!$orderList) {
             throw new \Exception('The provided order array is empty');
         }
 
-        $firstOrder = reset($orders);
+        $firstOrder = reset($orderList);
         $storeId = $firstOrder->getStoreId();
 
-        $orderIds = array_map( function (OrderInterface $order) { return $order->getId(); }, $orders);
+        $orderIds = array_map(function (OrderInterface $order) { return $order->getEntityId(); }, $orderList);
         $parameters = http_build_query([
             'order_ids' => $orderIds,
-            'payment_token' => $paymentToken,
+            'payment_tokens' => $paymentTokens,
             'utm_nooverride' => 1,
         ]);
 

--- a/Test/Integration/Service/Order/TransactionTest.php
+++ b/Test/Integration/Service/Order/TransactionTest.php
@@ -22,7 +22,7 @@ class TransactionTest extends IntegrationTestCase
 
         /** @var MultishippingTransaction $instance */
         $instance = $this->objectManager->create(MultishippingTransaction::class);
-        $result = $instance->getRedirectUrl($orders, 'PAYMENT_TOKEN_TEST');
+        $result = $instance->getRedirectUrl($orders, ['PAYMENT_TOKEN_TEST']);
 
         $this->assertStringContainsString('order_ids[0]=777', urldecode($result));
         $this->assertStringContainsString('order_ids[1]=888', urldecode($result));


### PR DESCRIPTION
Thank you for creating this pull request! To make the best use of your and our time we created this checklist to get the best possible pull requests:

- [x] The code is working on a plain Magento 2 installation.
- [x] The code follows the PSR-2 code style.
- [ ] When an exception or error is logged the message is accompanied with some context, eg: `Error when trying to get the payment status:`
- [x] Contains tests for the changed/added code (great if so but not required).
- [ ] I have added a scenario to test my changes.

**This PR touches code in the following areas (Check what is applicable):**

*Frontend*
- [ ] Shopping cart
- [ ] Checkout
- [ ] Totals
- [x] Payment methods

*Backend*
- [ ] Configuration
- [ ] Order grid
- [ ] Order view
- [ ] Invoice view
- [ ] Credit memo view
- [ ] Shipment view
- [ ] Email sending

*Order Processing (Mollie communication)*
- [x] Creating the order
- [ ] Invoicing the order
- [ ] Shipping the order
- [ ] Refunding (credit memo) the order

**Other**
If you didn't check any boxes above, please describe your changes in this section.

**Please describe the bug/feature/etc this PR contains:**

When i place an order that is a multishipping order, the code fails because the latest versions of the mollie module expects the same number of tokens as there are order-ids.
This PR fixes that problem by generating a token per order and not just for the first order in orderList.

**Scenario to test this code:**

Open the environment, place a multishipping order and pay with mollie.